### PR TITLE
Add new required argument to GetProject call

### DIFF
--- a/main.go
+++ b/main.go
@@ -157,7 +157,7 @@ func main() {
 
 			for {
 				// Step back through the tree to find the parent project path
-				proj, _, err := c.Projects.GetProject(rpath, gitlab.WithContext(r.Context()))
+				proj, _, err := c.Projects.GetProject(rpath, &gitlab.GetProjectOptions{}, gitlab.WithContext(r.Context()))
 				if err == nil {
 					cache.Add(r.URL.Path, proj)
 					sendResponse(w, r, proj)


### PR DESCRIPTION
This is a PR reflecting the change in one of the dependencies.

Merge request in go-gitlab [changed](https://github.com/xanzy/go-gitlab/pull/569/files#diff-ebeb10b961b2490421175ec9e1972041R337) `GetProject` signature to require new parameter: `GetProjectOptions`.
